### PR TITLE
New Feature: add KeysOfType

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ f(x)
 f(y)
 ```
 
+## KeysOfType<A extends object, B>
+
+Picks only the keys of a certain type
+
+```ts
+KeysOfType<{a: string, b: string | boolean, c: boolean, d: string}, string> // "a" | "d"
+```
+
 ## AnyTuple
 
 ```ts

--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -1,4 +1,4 @@
-import { AnyTuple, Equals, Exact, Omit, Overwrite, Diff, RowLacks, DeepReadonly } from '../src'
+import { AnyTuple, Equals, Exact, Omit, Overwrite, Diff, RowLacks, DeepReadonly, KeysOfType } from '../src'
 
 //
 // Equals
@@ -52,6 +52,13 @@ declare const exact2: { a: string; b: number }
 exactf1(exact1)
 // $ExpectError
 exactf1(exact2)
+
+//
+// KeysOfType
+//
+type KeysOfType1 = Equals<KeysOfType<{a: string, b: never}, never>, "b"> // $ExpectType "T"
+type KeysOfType2 = Equals<KeysOfType<{a: string, b: string}, string>, "a" | "b"> // $ExpectType "T"
+type KeysOfType3 = Equals<KeysOfType<{a: string, b: string | boolean}, string>, "a"> // $ExpectType "T"
 
 //
 // AnyTuple

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ export type Overwrite<A extends object, B extends object> = Pick<A, Exclude<keyo
 export type Diff<A extends object, K extends keyof A> = Omit<A, K> & Partial<Pick<A, K>>
 
 /**
-* Picks only the keys of a certain type
-*/
+ * Picks only the keys of a certain type
+ */
 export type KeysOfType<A extends object, B> = { [K in keyof A]: A[K] extends B ? K : never }[keyof A]
 
 /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,11 @@ export type Overwrite<A extends object, B extends object> = Pick<A, Exclude<keyo
 export type Diff<A extends object, K extends keyof A> = Omit<A, K> & Partial<Pick<A, K>>
 
 /**
+* Picks only the keys of a certain type
+*/
+export type KeysOfType<A extends object, B> = { [K in keyof A]: A[K] extends B ? K : never }[keyof A]
+
+/**
  * Encodes the constraint that a given object `A`
  * does not contain specific keys `K`
  */


### PR DESCRIPTION
This PR implements `KeysOfType<A extends object, B>` which will return all the keys where the value extends a given one.
This can be useful to implement things like `Clean<T>` which removes from an object the keys where the value is `never`

```ts
type Clean<T> = Pick<T, Exclude<keyof T, KeysOfType<T, never>>>
type TestClean = Clean<{a: string, b: never}> // => {a: string}
```

another real world usage is to discriminate functions and value properties in objects:

```ts
type ObjectFunctions<T> = Pick<T, KeysOfType<T, Function>>
type ObjectProperties<T>= Pick<T, Exclude<keyof T, KeysOfType<T, Function>>>
```
