### PR TITLE
handle empty object and primitives in RequiredKeys and OptionalKeys

### DIFF
--- a/dtslint/index.ts
+++ b/dtslint/index.ts
@@ -133,6 +133,7 @@ type BarForRequired = {
 
 type BarRequiredKeys = RequiredKeys<BarForRequired> // $ExpectType "a" | "b"
 type RequiredKeysIndexSignature = RequiredKeys<{[x: string]: any; a: number; b: Date; x?: string; y?: Date}> // $ExpectType "a" | "b"
+type RequiredKeysEmpty = RequiredKeys<{}> // $ExpectType never
 
 //
 // OptionalKeys
@@ -147,3 +148,4 @@ type BarForOptional = {
 
 type BarOptionalKeys = OptionalKeys<BarForOptional> // $ExpectType "x" | "y"
 type OptionalKeysIndexSignature = OptionalKeys<{[x: string]: any; a: number; b: Date; x?: string; y?: Date}> // $ExpectType "x" | "y"
+type OptionalKeysEmpty = OptionalKeys<{}> // $ExpectType never

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,9 @@ export type TaggedUnionMember<A extends object, Tag extends keyof A, Value exten
  * Extracts required keys as a literal type union
  */
 export type RequiredKeys<T> = { [K in keyof T]: {} extends Pick<T, K> ? never : K } extends { [_ in keyof T]: infer U }
-  ? U
+  ? {} extends U
+    ? never
+    : U
   : never
 
 /**
@@ -54,5 +56,7 @@ export type RequiredKeys<T> = { [K in keyof T]: {} extends Pick<T, K> ? never : 
 export type OptionalKeys<T> = { [K in keyof T]: T extends Record<K, T[K]> ? never : K } extends {
   [_ in keyof T]: infer U
 }
-  ? U
+  ? {} extends U
+    ? never
+    : U
   : never


### PR DESCRIPTION
Before this change `RequiredKeys<{}>` for example yielded `{}` instead of `never`.